### PR TITLE
retry openstates api if we get a 404

### DIFF
--- a/openstatesapi/base.py
+++ b/openstatesapi/base.py
@@ -1,6 +1,7 @@
 from pupa.scrape import Scraper
 import os.path
 import os
+from scrapelib import HTTPError
 
 
 class OpenstatesBaseScraper(Scraper):
@@ -29,7 +30,7 @@ class OpenstatesBaseScraper(Scraper):
                 "~/.sunlight.key"
             )
 
-    def api(self, method):
+    def api(self, method, retrys=4):
         """
         Preform an API call against `method`. Return the parsed json
         data.
@@ -39,7 +40,10 @@ class OpenstatesBaseScraper(Scraper):
             "&" if "?" in method else "?",
             self.apikey
         )
+
+        self.retry_attempts = retrys
         try:
-            return self.get(url).json()
+            return self.get(url,retry_on_404=True).json()
+
         except ValueError:
             raise ValueError('error retrieving ' + url)

--- a/openstatesapi/base.py
+++ b/openstatesapi/base.py
@@ -1,7 +1,6 @@
 from pupa.scrape import Scraper
 import os.path
 import os
-from scrapelib import HTTPError
 
 
 class OpenstatesBaseScraper(Scraper):


### PR DESCRIPTION
We're crashing a few os->ocd scrapers each night on 404 errors for pages I can access by hand without issue. eg http://moxie.sunlightlabs.com/run/1904/